### PR TITLE
Add gun_right_m / gun_up_m for gun-stock calibration (H3/ODST/Reach)

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -375,6 +375,8 @@ static void Clamp()
     g_config.gun_yaw_deg = std::clamp(g_config.gun_yaw_deg, -180.0f, 180.0f);
     g_config.gun_roll_deg = std::clamp(g_config.gun_roll_deg, -180.0f, 180.0f);
     g_config.gun_forward_m = std::clamp(g_config.gun_forward_m, -0.3f, 0.5f);
+    g_config.gun_right_m = std::clamp(g_config.gun_right_m, -0.3f, 0.3f);
+    g_config.gun_up_m = std::clamp(g_config.gun_up_m, -0.3f, 0.3f);
     g_config.muzzle_height_m = std::clamp(g_config.muzzle_height_m, -0.3f, 0.3f);
     g_config.scope_zoom = std::clamp(g_config.scope_zoom, 6.0f, 24.0f);
     g_config.scope_screen_width_m = std::clamp(g_config.scope_screen_width_m, 0.04f, 0.25f);
@@ -613,6 +615,10 @@ void ConfigLoad(const wchar_t* path)
             g_config.gun_roll_deg = (float)atof(val);
         else if (!strcmp(key, "gun_forward_m"))
             g_config.gun_forward_m = (float)atof(val);
+        else if (!strcmp(key, "gun_right_m"))
+            g_config.gun_right_m = (float)atof(val);
+        else if (!strcmp(key, "gun_up_m"))
+            g_config.gun_up_m = (float)atof(val);
         else if (!strcmp(key, "muzzle_height_m"))
             g_config.muzzle_height_m = (float)atof(val);
         else if (!strcmp(key, "scope_enabled"))
@@ -990,6 +996,10 @@ void ConfigSave()
     fprintf(f, "# Negative seats the gun back into your fist.\n");
     fprintf(f, "# (default %.2f, range -0.3 to 0.5)\n", d.gun_forward_m);
     fprintf(f, "gun_forward_m = %.2f\n\n", g_config.gun_forward_m);
+    fprintf(f, "# Sideways and vertical mount offsets on the controller, in meters.\n");
+    fprintf(f, "# (defaults 0.00 / 0.00, range -0.3 to 0.3)\n");
+    fprintf(f, "gun_right_m = %.2f\n", g_config.gun_right_m);
+    fprintf(f, "gun_up_m = %.2f\n\n", g_config.gun_up_m);
     fprintf(f, "# Raise the muzzle flash / bullet spawn point along the gun's\n");
     fprintf(f, "# own up axis, in meters. Reach only. Does NOT change where\n");
     fprintf(f, "# rounds land - only where they appear to come from.\n");

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -534,6 +534,14 @@ struct Config
     // positive moves it out of your face. Never touches aim.
     float gun_forward_m = -0.14f;
 
+    // Lateral mount offsets in METERS, along the controller's own right and
+    // up axes AFTER the mount rotation. 0 = gun hangs straight off the
+    // controller. These exist because a gun stock needs an arbitrary
+    // physical offset: rotation alone cannot reach a point not on the arc.
+    // Visual only, like all gun trims; the cursor/bullet ray never moves.
+    float gun_right_m = 0.0f;
+    float gun_up_m = 0.0f;
+
     // Raise the muzzle EFFECT origin — the flash and the point bullets appear
     // to leave — along the gun's own up axis, in meters. Reach only; Halo 3 and
     // ODST resolve their muzzle markers on the visible weapon already.

--- a/src/dll/game.cpp
+++ b/src/dll/game.cpp
@@ -5330,8 +5330,14 @@ namespace
         const float standoff = (left
             ? Clamp(g_config.left_hand_forward_m, -0.15f, 0.30f)
             : Clamp(g_config.gun_forward_m, -0.3f, 0.5f)) * s;
+        // K1: gun-stock offsets along the controller's own right (col 1) and
+        // up (col 2) axes, after the mount rotation. Visual only - the bullet
+        // ray stays on the controller, exactly like gun_forward_m.
+        const float rightOff = !left ? Clamp(g_config.gun_right_m, -0.3f, 0.3f) * s : 0.0f;
+        const float upOff = !left ? Clamp(g_config.gun_up_m, -0.3f, 0.3f) * s : 0.0f;
         for (int j = 0; j < 3; ++j)
-            pos[j] = cam[j] + off[j] + basis[j] * standoff;
+            pos[j] = cam[j] + off[j] + basis[j] * standoff +
+                     basis[3 + j] * rightOff + basis[6 + j] * upOff;
         scale = Clamp(g_config.gun_scale, 0.3f, 3.0f);
         for (int j = 0; j < 9; ++j) if (!isfinite(basis[j])) return false;
         for (int j = 0; j < 3; ++j) if (!isfinite(pos[j])) return false;
@@ -21656,12 +21662,16 @@ namespace
         const float standoff=(left
             ? Clamp(g_config.left_hand_forward_m,-0.15f,0.30f)
             : Clamp(g_config.gun_forward_m,-0.3f,0.5f))*scale;
+        // K1: gun-stock offsets along controller right (col 1) / up (col 2),
+        // post-mount-rotation. Visual only; the bullet ray never moves.
+        const float rightOff=!left ? Clamp(g_config.gun_right_m,-0.3f,0.3f)*scale : 0.0f;
+        const float upOff   =!left ? Clamp(g_config.gun_up_m,-0.3f,0.3f)*scale   : 0.0f;
         out={};
         out.scale=1.0f;
         memcpy(out.rotation,basis,sizeof(basis));
         for (int axis=0;axis<3;++axis)
             out.translation[axis]=gameplayBase[axis]+offset[axis]+
-                basis[axis]*standoff;
+                basis[axis]*standoff + basis[3+axis]*rightOff + basis[6+axis]*upOff;
         meshScale=left
             ? Clamp(g_config.left_hand_scale,0.3f,3.0f)
             : Clamp(g_config.gun_scale,0.3f,3.0f);

--- a/src/dll/menu.cpp
+++ b/src/dll/menu.cpp
@@ -1032,6 +1032,14 @@ namespace
         ImGui::TextDisabled("0/0/0 keeps the current automatic barrel alignment.");
         changed |= ImGui::SliderFloat("Gun forward offset (m)", &g_config.gun_forward_m, -0.3f, 0.5f, "%.2f");
         ImGui::TextDisabled("Slides gun/arms along your aim. Negative seats the gun back in your fist.");
+        changed |= ImGui::SliderFloat("Gun right offset (m)", &g_config.gun_right_m, -0.3f, 0.3f, "%.2f");
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Center##gnrx")) { g_config.gun_right_m = 0.0f; changed = true; }
+        changed |= ImGui::SliderFloat("Gun up offset (m)", &g_config.gun_up_m, -0.3f, 0.3f, "%.2f");
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Center##gnux")) { g_config.gun_up_m = 0.0f; changed = true; }
+        ImGui::TextDisabled("Move the gun sideways on its own local right/up axes (post-rotation).");
+        ImGui::TextDisabled("For gun-stock alignment. Visual only; your shots still come from the controller.");
         changed |= ImGui::SliderFloat("Muzzle height (m)", &g_config.muzzle_height_m, -0.3f, 0.3f, "%.2f");
         ImGui::TextDisabled("HALO REACH ONLY for now - Halo 3 and ODST support is coming soon.");
         ImGui::TextDisabled("Raises the muzzle flash / bullet spawn up the gun's own axis.");


### PR DESCRIPTION
## What & why

The weapon mount currently exposes only rotation (`gun_pitch/yaw/roll_deg`)
and a single forward translation (`gun_forward_m`). Rotation has a hard
limitation for a large group of players: **gun-stock users** cannot align and
calibrate the rendered gun to their physical stock with yaw/pitch/roll alone,
because a stock mount point is an arbitrary offset from the controller, not a
point on a rotation arc. Reaching it inevitably requires left/right and
up/down translation.

This adds two knobs that cover exactly that requirement:

- `gun_right_m` — moves the gun along the controller's own local right axis
- `gun_up_m` — moves the gun along the controller's own local up axis

both in meters, default 0.00, clamped to ±0.30. They are applied to the
controller's POST-mount-rotation basis, so they follow the user's yaw/pitch/
roll trim exactly as a physical mount does.

## What it touches

- `src/common/config.h` — two new floats
- `src/common/config.cpp` — parse + clamp + write the two keys (cfg + F1 save)
- `src/dll/game.cpp` — both engine pose builders (H3/ODST and Reach)
- `src/dll/menu.cpp` — two sliders under Weapon calibration, with reset buttons

38 insertions, 2 deletions, isolated to one feature. No changes to vehicles,
HUD, render, or any other subsystem; no game files patched.

## Why it is safe

Visual only — consistent with the existing gun trims. The cursor/bullet ray
stays fixed on the controller, which is unchanged behavior. The left hand is
untouched (it has its own forward seat + mirrored rotation already).

## How it works

Same 3x3 column-major convention the codebase already uses:
`basis[3+j]` = right, `basis[6+j]` = up. Example (H3/ODST path):

```cpp
const float rightOff = !left ? Clamp(g_config.gun_right_m, -0.3f, 0.3f) * s : 0.0f;
const float upOff = !left ? Clamp(g_config.gun_up_m, -0.3f, 0.3f) * s : 0.0f;
for (int j = 0; j < 3; ++j)
    pos[j] = cam[j] + off[j] + basis[j]*standoff +
             basis[3+j]*rightOff + basis[6+j]*upOff;
```

Happy to rename keys / change ranges / adjust defaults if you'd prefer a
different convention — the intent is just to give stock players real X/Y/Z
placement trims, not a specific API.

Tested in-headset by me; works on Halo 3.
